### PR TITLE
Add support for building gem via a docker container with makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 Gemfile.lock
 .bundle
 vendor
+pkg

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM jruby:9.1-alpine as logstash-filter-de_dot
+
+ENV LOGSTASH_BRANCH=v6.5.1
+
+RUN java -Xmx32m -version
+
+RUN gem install bundler -v '< 2'
+
+RUN apk add --no-cache \
+      openjdk8 \
+      git
+
+RUN mkdir logstash-filter-de_dot
+
+ADD Gemfile Rakefile *.gemspec logstash-filter-de_dot/
+ADD ci logstash-filter-de_dot/ci/
+ADD lib logstash-filter-de_dot/ci/lib/
+ADD spec logstash-filter-de_dot/ci/spec/
+
+WORKDIR logstash-filter-de_dot
+
+RUN source ./ci/setup.sh && \
+    bundle update && \
+    bundle install && \
+    truncate -s 0 /logstash/logstash-core/lib/logstash/patches/resolv.rb && \
+    bundle exec rake vendor && \
+    bundle exec rspec spec && \
+    bundle exec gem build logstash-filter-de_dot.gemspec
+
+ADD docker-entrypoint.sh /
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+default: build
+
+build:
+	docker-compose build
+	docker-compose run build

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,7 @@
+version: '2.4'
+
+services:
+  build:
+    build: .
+    volumes:
+    - ./pkg:/logstash-filter-de_dot/pkg

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+find -maxdepth 1 -name '*.gem' -exec cp -v {} pkg/ \;


### PR DESCRIPTION
Adds support for building the gem via a docker container. This removes the need for a local build environment. Makefile support added to simplify the need to know the appropriate docker commands.